### PR TITLE
Add support for playlists in Charts

### DIFF
--- a/catalog_charts.go
+++ b/catalog_charts.go
@@ -26,11 +26,19 @@ type ChartMusicVideos struct {
 	MusicVideos
 }
 
+// ChartPlaylists represent a chart of playlists.
+type ChartPlaylists struct {
+	Name  string `json:"name"`
+	Chart string `json:"chart"`
+	Playlists
+}
+
 // ChartResults represents a results, that contains chart collections.
 type ChartResults struct {
 	Albums      *[]ChartAlbums      `json:"albums,omitempty"`
 	Songs       *[]ChartSongs       `json:"songs,omitempty"`
 	MusicVideos *[]ChartMusicVideos `json:"music-videos,omitempty"`
+	Playlists   *[]ChartPlaylists   `json:"playlists,omitempty"`
 }
 
 // Charts represents the result of one or more charts.

--- a/catalog_playlists.go
+++ b/catalog_playlists.go
@@ -47,7 +47,7 @@ type Playlist struct {
 	Type          string                `json:"type"`
 	Href          string                `json:"href"`
 	Attributes    PlaylistAttributes    `json:"attributes"`
-	Relationships PlaylistRelationships `json:"relationships"`
+	Relationships PlaylistRelationships `json:"relationships,omitempty"`
 }
 
 // Playlists represents a list of playlists.


### PR DESCRIPTION
Apple's Chart endpoint supports playlists: https://developer.apple.com/documentation/applemusicapi/get_catalog_charts

View the response object. Here's a sample output:

```
{
   "results":{
      "playlists":[
         {
            "name":"Top Playlists",
            "chart":"most-played",
            "href":"/v1/catalog/us/charts?chart=most-played&types=playlists",
            "next":"/v1/catalog/us/charts?chart=most-played&offset=20&types=playlists",
            "data":[
               {
                  "id":"pl.abe8ba42278f4ef490e3a9fc5ec8e8c5",
                  "type":"playlists",
                  "href":"/v1/catalog/us/playlists/pl.abe8ba42278f4ef490e3a9fc5ec8e8c5",
                  "attributes":{
                     "artwork":{
                        "width":4320,
                        "height":1080,
                        "url":"https://is5-ssl.mzstatic.com/image/thumb/Features128/v4/be/ca/be/becabe5c-150a-3dd7-a0d6-a39edc1760a2/source/{w}x{h}cc.jpeg",
                        "bgColor":"790000",
                        "textColor1":"ecedf0",
                        "textColor2":"d2d3d8",
                        "textColor3":"d5bdc0",
                        "textColor4":"c0a9ad"
                     },
                     "curatorName":"Apple Music Hip-Hop",
                     "playlistType":"editorial",
                     "lastModifiedDate":"2018-10-12T21:33:31Z",
                     "description":{
                        "standard":"After combing through countless releases each week, our editors select their favorites for The A-List: Hip-Hop—the hottest tracks from across the genre. This playlist is updated regularly, so if you like a song, add it to your library.",
                        "short":"This week's best—selected by our editors."
                     },
                     "playParams":{
                        "id":"pl.abe8ba42278f4ef490e3a9fc5ec8e8c5",
                        "kind":"playlist"
                     },
                     "url":"https://itunes.apple.com/us/playlist/the-a-list-hip-hop/pl.abe8ba42278f4ef490e3a9fc5ec8e8c5",
                     "name":"The A-List: Hip-Hop"
                  }
               }
            ]
         }
      ]
   }
}
```

A request:

`curl -v -H 'Authorization: TOKEN' https://api.music.apple.com/v1/catalog/us/charts\?chart\=most-played\&types\=playlists`

This change adds parsing Playlists to the Chart object