### PR TITLE
Add catalogId for PlayParameters

### DIFF
--- a/catalog_songs.go
+++ b/catalog_songs.go
@@ -27,6 +27,7 @@ type SongAttributes struct {
 	MovementNumber   int             `json:"movementNumber,omitempty"`
 	WorkName         string          `json:"workName,omitempty"`
 	Previews         *[]Preview      `json:"previews,omitempty"`
+	AlbumName        string          `json:"albumName"`
 }
 
 // SongRelationships represents a to-one or to-many relationship from one resource object to others.

--- a/catalog_songs.go
+++ b/catalog_songs.go
@@ -26,6 +26,7 @@ type SongAttributes struct {
 	MovementName     string          `json:"movementName,omitempty"`
 	MovementNumber   int             `json:"movementNumber,omitempty"`
 	WorkName         string          `json:"workName,omitempty"`
+	Previews         *[]Preview      `json:"previews,omitempty"`
 }
 
 // SongRelationships represents a to-one or to-many relationship from one resource object to others.

--- a/resource.go
+++ b/resource.go
@@ -69,3 +69,8 @@ type PlayParameters struct {
 	IsLibrary bool   `json:"isLibrary,omitempty"` // Undocumented, Used in LibraryPlaylist.
 	CatalogId string `json:"catalogId,omitempty"` // Undocumented, Used in LibraryPlaylist.
 }
+
+// Preview represents an audio preview for resources.
+type Preview struct {
+	Url string `json:"url"`
+}

--- a/resource.go
+++ b/resource.go
@@ -67,4 +67,5 @@ type PlayParameters struct {
 	Id        string `json:"id"`
 	Kind      string `json:"kind"`
 	IsLibrary bool   `json:"isLibrary,omitempty"` // Undocumented, Used in LibraryPlaylist.
+	CatalogId string `json:"catalogId,omitempty"` // Undocumented, Used in LibraryPlaylist.
 }


### PR DESCRIPTION
When fetching a library song, Apple Music API will return catalogId of the song if it exists.

Example of Library song object:
```json
    {
      "id": "i.NOlxHWGxAp1",
      "type": "library-songs",
      "href": "/v1/me/library/songs/i.NOlxHWGxAp1",
      "attributes": {
        "artwork": {
          "width": 1200,
          "height": 1200,
          "url": "https://is2-ssl.mzstatic.com/image/thumb/Music118/v4/d5/74/93/d57493d9-68e3-a71f-718a-820b31a8ef4a/00602577107870.rgb.jpg/{w}x{h}bb.jpeg"
        },
        "artistName": "Ella Mai",
        "genreNames": [
          "R&B/Soul"
        ],
        "durationInMillis": 213993,
        "releaseDate": "2018-08-03",
        "name": "Trip",
        "albumName": "Ella Mai",
        "playParams": {
          "id": "i.NOlxHWGxAp1",
          "kind": "song",
          "isLibrary": true,
          "reporting": true,
          "catalogId": "1436555518"
        },
        "trackNumber": 13
      }
    }
```