### PR TITLE
make sure we don't override the current query values when giving options

### DIFF
--- a/applemusic.go
+++ b/applemusic.go
@@ -95,7 +95,16 @@ func addOptions(s string, opt interface{}) (string, error) {
 		return s, err
 	}
 
-	u.RawQuery = qs.Encode()
+	// We keep the values that were already present and add the new
+	// options to them
+	queryValues := u.Query()
+	for k, v := range qs {
+		for _, param := range v {
+			queryValues.Add(k, param)
+		}
+	}
+
+	u.RawQuery = queryValues.Encode()
 	return u.String(), nil
 }
 

--- a/applemusic_test.go
+++ b/applemusic_test.go
@@ -111,6 +111,18 @@ func Test_makeIdsOptions(t *testing.T) {
 	}
 }
 
+// test we don't override the params already given when another param is specified in the url
+func Test_addOptions_noParamsOverride(t *testing.T) {
+	actualParams := "?offset=100"
+
+	want := "/v1/me/library/playlists/p.2P6WgVAuVeYx3OB/tracks?l=fr&offset=100"
+	got, _ := addOptions("/v1/me/library/playlists/p.2P6WgVAuVeYx3OB/tracks" + actualParams, Options{Language: "fr"})
+
+	if got != want {
+		t.Errorf("Url is %s, want %s", got, want)
+	}
+}
+
 func TestNewClient(t *testing.T) {
 	c := NewClient(nil)
 


### PR DESCRIPTION
Hey there :) Thanks a bunch for your lib that is awesome !

I found a bug that occurs when I specify options and the API makes us paginate.

For example, imagine I give some options in the following request

```
catalogSongs, _, err := client.Catalog.GetSongsByIds(ctx, "fr", ids, &applemusic.Options{Language: "fr"})
```

What will happen when I paginate is that the offset param when we will paginate and go through all the songs 100 by 100, will be overridden by my param `l=fr`

If you look at the test, the query

```
/v1/me/library/playlists/p.2P6WgVAuVeYx3OB/tracks?offset=100
```

would be transformed to 

```
/v1/me/library/playlists/p.2P6WgVAuVeYx3OB/tracks?l=fr
```

instead of 

```
/v1/me/library/playlists/p.2P6WgVAuVeYx3OB/tracks?l=fr&offset=100
```

As we lost the offset, we will paginate for ever and thus => not great :p 

Hope you like the fix!

Again, thanks for this great lib