### PR TITLE
add methods to create a playlist and add track to it

### DIFF
--- a/applemusic_test.go
+++ b/applemusic_test.go
@@ -61,6 +61,19 @@ func testFormValues(t *testing.T, r *http.Request, values values) {
 	}
 }
 
+func testJsonBodyValues(t *testing.T, r *http.Request, j []byte) {
+	body, _ := ioutil.ReadAll(r.Body)
+	var got map[string]interface{}
+	_ = json.Unmarshal(body, &got)
+
+	var want map[string]interface{}
+	_ = json.Unmarshal(j, &want)
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Request body: %v, want %v", got, want)
+	}
+}
+
 func testURLParseError(t *testing.T, err error) {
 	if err == nil {
 		t.Errorf("Expected error to be returned")

--- a/me_library_playlists.go
+++ b/me_library_playlists.go
@@ -102,3 +102,64 @@ func (s *MeService) GetLibraryPlaylistTracks(ctx context.Context, id string, opt
 
 	return tracks, nil
 }
+
+type CreateLibraryPlaylistAttributes struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+type CreateLibraryPlaylistTrack struct {
+	Id   string `json:"id"`
+	Type string `json:"type"`
+}
+
+type CreateLibraryPlaylistTrackData struct {
+	Data []CreateLibraryPlaylistTrack `json:"data"`
+}
+
+type CreateLibraryPlaylistRelationships struct {
+	Tracks CreateLibraryPlaylistTrackData `json:"tracks"`
+}
+
+type CreateLibraryPlaylist struct {
+	Attributes    CreateLibraryPlaylistAttributes     `json:"attributes"`
+	Relationships *CreateLibraryPlaylistRelationships `json:"relationships,omitempty"`
+}
+
+func (s *MeService) CreateLibraryPlaylist(ctx context.Context, body CreateLibraryPlaylist, opt *Options) (*LibraryPlaylists, *Response, error) {
+	u := "v1/me/library/playlists"
+
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("POST", u, body)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	libraryPlaylists := &LibraryPlaylists{}
+	resp, err := s.client.Do(ctx, req, libraryPlaylists)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return libraryPlaylists, resp, nil
+}
+
+func (s *MeService) AddLibraryTracksToPlaylist(ctx context.Context, playlistId string, body CreateLibraryPlaylistTrackData) (*Response, error) {
+	u := fmt.Sprintf("/v1/me/library/playlists/%s/tracks", playlistId)
+
+	req, err := s.client.NewRequest("POST", u, body)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.Do(ctx, req, nil)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}


### PR DESCRIPTION
The client was missing 2 features:

- create a new library playlist https://developer.apple.com/documentation/applemusicapi/create_a_new_library_playlist
- add songs to a library playlist https://developer.apple.com/documentation/applemusicapi/add_tracks_to_a_library_playlist