### PR TITLE
adds count response to playlists library track API

### DIFF
--- a/me_library.go
+++ b/me_library.go
@@ -8,6 +8,7 @@ type LibraryPlaylistAttributes struct {
 	PlayParams  *PlayParameters `json:"playParams"`
 	CanDelete   bool            `json:"canDelete"`
 	CanEdit     bool            `json:"canEdit"`
+	HasCatalog  bool            `json:"hasCatalog"`
 }
 
 // LibraryPlaylistRelationships represents a to-one or to-many relationship from one resource object to others.


### PR DESCRIPTION
- Adds count response to playlists library track API
- Adds HasCatalog to playlist attribute response

The meta field in the response example:
https://developer.apple.com/documentation/applemusicapi/get_a_library_playlist_s_relationship_directly_by_name