### PR TITLE
added song catalog relationship and reporting property

### DIFF
--- a/catalog_songs.go
+++ b/catalog_songs.go
@@ -31,9 +31,10 @@ type SongAttributes struct {
 
 // SongRelationships represents a to-one or to-many relationship from one resource object to others.
 type SongRelationships struct {
-	Albums  Albums  `json:"albums"`           // Default inclusion: Identifiers only
-	Artists Artists `json:"artists"`          // Default inclusion: Identifiers only
-	Genres  *Genres `json:"genres,omitempty"` // Default inclusion: None
+	Albums  Albums  `json:"albums"`            // Default inclusion: Identifiers only
+	Artists Artists `json:"artists"`           // Default inclusion: Identifiers only
+	Genres  *Genres `json:"genres,omitempty"`  // Default inclusion: None
+	Catalog *Songs  `json:"catalog,omitempty"` // Default inclusion: None
 }
 
 // Song represents a song.

--- a/resource.go
+++ b/resource.go
@@ -68,6 +68,7 @@ type PlayParameters struct {
 	Kind      string `json:"kind"`
 	IsLibrary bool   `json:"isLibrary,omitempty"` // Undocumented, Used in LibraryPlaylist.
 	CatalogId string `json:"catalogId,omitempty"` // Undocumented, Used in LibraryPlaylist.
+	Reporting bool   `json:"reporting,omitempty"` // Undocumented, Used in LibraryPlaylist.
 }
 
 // Preview represents an audio preview for resources.


### PR DESCRIPTION
Added the Catalog and reporting properties. These are useful if you include catalog to a library song call.
example:
```
client.Me.GetLibraryPlaylistTracks(ctx, applePlaylistId, &applemusic.PageOptions{Limit: 100, Options: applemusic.Options{Include: "catalog"}})
```