### PR TITLE
feat(me_history_recently_played_tracks): add ArtistURL property support

### DIFF
--- a/applemusic.go
+++ b/applemusic.go
@@ -48,6 +48,9 @@ type Options struct {
 
 	// Additional relationships to include in the fetch.
 	Include string `url:"include,omitempty"`
+
+	// Additional relationships to extend in the fetch.
+	Extend string `url:"extend,omitempty"`
 }
 
 // PageOptions specifies the optional parameters to support pagination of the objects.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/minchao/go-apple-music
+module github.com/darkweak/go-apple-music
 
 go 1.13
 

--- a/me_history_recently_played_tracks.go
+++ b/me_history_recently_played_tracks.go
@@ -6,6 +6,7 @@ import "context"
 type HistoryRecentlyPlayedTrackAttributes struct {
 	AlbumName            string         `json:"albumName"`
 	ArtistName           string         `json:"artistName"`
+	ArtistURL            string         `json:"artistUrl,omitempty"`
 	Artwork              Artwork        `json:"artwork"`
 	DiscNumber           int            `json:"discNumber"`
 	DurationInMillis     int64          `json:"durationInMillis,omitempty"`

--- a/me_history_recently_played_tracks_test.go
+++ b/me_history_recently_played_tracks_test.go
@@ -52,6 +52,7 @@ func TestMeService_GetHistoryRecentlyPlayedTracks(t *testing.T) {
 				"url": "https://audio-ssl.itunes.apple.com/itunes-assets/AudioPreview115/v4/51/a3/67/51a36707-d65a-81f3-fe31-59804fb2bdfa/mzaf_13431577798219308851.plus.aac.p.m4a"
 			  }
 			],
+			"artistUrl": "https://music.apple.com/de/artist/forss/7018169",
 			"artistName": "Forss"
 		  }
 		},


### PR DESCRIPTION
Hello,

For a side project I need the extended property artist_url populated in the `me_history_recently_played_tracks` object result.